### PR TITLE
Add support for additional AD settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ var autodiscover = require('exchange-autodiscover');
 autodiscover({ emailAddress: "foo@bar.onmicrosoft.com", password: "pass"  })
   .then(console.log.bind(console))  // "https://outlook.microsoft.com/ews/exchange.asmx"
   .catch(console.error.bind(console))
-  
+
 // Callback
 autodiscover({ emailAddress: "foobar@yourdomain.com", password: "pass", username: "ad\\foobar77" },
   function(err, ewsUrl) {
@@ -24,6 +24,30 @@ autodiscover({ emailAddress: "foobar@yourdomain.com", password: "pass", username
     }
   }
 ```
+
+You can optionally request any of the [extra settings found here](https://msdn.microsoft.com/en-us/library/office/dd877068(v=exchg.150).aspx):
+
+```javascript
+// With extra settings
+autodiscover({
+  emailAddress: "foo@bar.onmicrosoft.com",
+  password: "pass",
+  settings: [
+    'EwsSupportedSchemas',
+    'ExternalEwsVersion'
+  ]
+}).then(function (settings) {
+  console.log(settings)
+  // Sample response
+  // {
+  //   EwsSupportedSchemas: 'Exchange2007, Exchange2007_SP1, Exchange2010, Exchange2010_SP1, Exchange2010_SP2, Exchange2013, Exchange2013_SP1, Exchange2015',
+  //   ExternalEwsUrl: 'https://outlook.office365.com/EWS/Exchange.asmx',
+  //   ExternalEwsVersion: '15.00.0000.000'
+  // }
+});
+```
+
+This will return an object with matched settings. (EWS address will always be included by default).
 
 ## API
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ var Promise = require('bluebird');
 var rp = require('request-promise');
 var dnsResolve = Promise.promisify(require('dns').resolve);
 var parseString = Promise.promisify(require('xml2js').parseString);
+const EWS_URL_SETTING = 'ExternalEwsUrl';
 
 /**
  * Removes the potential prefix of a string and makes the first character
@@ -63,7 +64,24 @@ function tryEndpoint(url, username, password, requestBody) {
   });
 }
 
-function createAutodiscoverSoap(emailAddress) {
+/**
+ * Formats requested settings for SOAP (i.e. <a:Setting>SETTING</a:Setting>).
+ *
+ * https://msdn.microsoft.com/en-us/library/office/dd877068(v=exchg.150).aspx
+ *
+ * @param  {?Array|String} settings List of AD settings to request.
+ * @return {String} Setting nodes to embed in SOAP XML request.
+ */
+function wrapSettingsRequest(settings) {
+  // Allows settings to be both arrays and single strings
+  settings = [].concat(settings);
+  // Only add EWS Url if it's missing
+  if (settings.indexOf(EWS_URL_SETTING) === -1)
+    settings.push(EWS_URL_SETTING)
+  return settings.map(setting => `<a:Setting>${setting}</a:Setting>`).join('');
+};
+
+function createAutodiscoverSoap(emailAddress, settings) {
   return '' +
     '<?xml version="1.0" encoding="utf-8"?>' +
     '<soap:Envelope xmlns:a="http://schemas.microsoft.com/exchange/2010/Autodiscover" ' +
@@ -82,9 +100,7 @@ function createAutodiscoverSoap(emailAddress) {
     '            <a:Mailbox>' + emailAddress + '</a:Mailbox>' +
     '          </a:User>' +
     '        </a:Users>' +
-    '        <a:RequestedSettings>' +
-    '          <a:Setting>ExternalEwsUrl</a:Setting>' +
-    '        </a:RequestedSettings>' +
+    '        <a:RequestedSettings>' + wrapSettingsRequest(settings) + '</a:RequestedSettings>' +
     '      </a:Request>' +
     '    </a:GetUserSettingsRequestMessage>' +
     '  </soap:Body>' +
@@ -100,11 +116,12 @@ function createAutodiscoverSoap(emailAddress) {
  * @param {String} emailAddress
  * @param {String} password
  * @param {String} username
+ * @param {?Array|String} Requested settings
  * @returns {Promise}
  */
-function autodiscoverDomains(domains, emailAddress, password, username) {
+function autodiscoverDomains(domains, emailAddress, password, username, settings) {
   var promises = [];
-  var requestBody = createAutodiscoverSoap(emailAddress);
+  var requestBody = createAutodiscoverSoap(emailAddress, settings);
   domains.forEach(domain => {
     promises.push(tryEndpoint('https://' + domain + '/autodiscover/autodiscover.svc',
       username, password, requestBody));
@@ -130,8 +147,16 @@ function autodiscoverDomains(domains, emailAddress, password, username) {
   return Promise
     .any(promises)
     .then(xmlToJson)
-    .then(result => result.envelope.body.getUserSettingsResponseMessage
-      .response.userResponses.userResponse.userSettings.userSetting.value);
+    .then(result => {
+      var userSettings = result.envelope.body.getUserSettingsResponseMessage
+        .response.userResponses.userResponse.userSettings.userSetting;
+      // Make sure we're working with an array
+      userSettings = [].concat(userSettings);
+      return userSettings.reduce((userSettings, setting) => {
+        userSettings[setting.name] = setting.value;
+        return userSettings;
+      }, {});
+    });
 }
 
 /**
@@ -142,6 +167,7 @@ function autodiscoverDomains(domains, emailAddress, password, username) {
  * @param {String} params.password
  * @param {String} [params.username]
  * @param {Boolean} [params.queryDns]
+ * @param {Array} [params.settings]
  * @param {Function} [cb]
  * @returns {Promise} Resolves with the EWS url
  */
@@ -150,6 +176,7 @@ module.exports = function (params, cb) {
   var password = params.password;
   var username = params.username || emailAddress;
   var query = params.queryDns || true;
+  var requestedSettings = params.settings;
 
   var smtpDomain = emailAddress.substr(emailAddress.indexOf("@") + 1);
   var domains = [smtpDomain];
@@ -163,13 +190,15 @@ module.exports = function (params, cb) {
   return promise
     .then(otherDomains => {
       domains = domains.concat(otherDomains);
-      return autodiscoverDomains(domains, emailAddress, password, username);
+      return autodiscoverDomains(domains, emailAddress, password, username, requestedSettings);
     })
-    .then(ewsUrl => {
+    .then(settings => {
+      // If no extra settings were requested, just return the EWS URL as string
+      var result = requestedSettings ? settings : settings[EWS_URL_SETTING];
       if (cb) {
-        cb(null, ewsUrl);
+        cb(null, result);
       }
-      return ewsUrl;
+      return result;
     })
     .catch(errors => {
       if (cb) {


### PR DESCRIPTION
Adds support for extra settings from Autodiscover. Gist below:

You can optionally request any of the [extra settings found here](https://msdn.microsoft.com/en-us/library/office/dd877068%28v=exchg.150%29.aspx):

``` javascript
// With extra settings
autodiscover({
  emailAddress: "foo@bar.onmicrosoft.com",
  password: "pass",
  settings: [
    'EwsSupportedSchemas',
    'ExternalEwsVersion'
  ]
}).then(function (settings) {
  console.log(settings)
  // Sample response
  // {
  //   EwsSupportedSchemas: 'Exchange2007, Exchange2007_SP1, Exchange2010, Exchange2010_SP1, Exchange2010_SP2, Exchange2013, Exchange2013_SP1, Exchange2015',
  //   ExternalEwsUrl: 'https://outlook.office365.com/EWS/Exchange.asmx',
  //   ExternalEwsVersion: '15.00.0000.000'
  // }
});
```

This will return an object with matched settings. (EWS address will always be included by default).
