### PR TITLE
Remove unused DNS dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "repository": "EmilTholin/node-exchange-autodiscover",
   "dependencies": {
     "bluebird": "^3.0.6",
-    "dns": "^0.2.2",
     "request-promise": "^1.0.2",
     "xml2js": "^0.4.15"
   }


### PR DESCRIPTION
[Node supports DNS API's out of the box](https://nodejs.org/api/dns.html), and it seems this library already uses the `dns.resolve` method from it: https://github.com/EmilTholin/node-exchange-autodiscover/blob/master/lib/index.js#L46-L49

The `dns` dependency listed in the manifest (https://github.com/hbouvier/dns) isn't actually in use. It also has the unfortunate side effect of requiring a handful of bloated sub-dependencies such as [tomahawk](https://github.com/hbouvier/tomahawk) (has platform restrictions) and `socket-io`, which cause unnecessary compatibility problems when using this fine library alone.

This change is simply removing `dns` from the dependencies.
